### PR TITLE
changed lineComment to # and removed block comment

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#",
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Hello Peter, 

enjoy using your extensions. However I think the comments section was not correct. Line-comments in HAL are # and to my knowledge there is no block comment syntax in HAL.

Regards, 

Marc